### PR TITLE
chore: add commands to clean dist dir and publish process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2527,7 +2527,7 @@
         "mkdirp": "0.5.1",
         "move-concurrently": "1.0.1",
         "promise-inflight": "1.0.1",
-        "rimraf": "2.6.2",
+        "rimraf": "2.6.3",
         "ssri": "6.0.1",
         "unique-filename": "1.1.1",
         "y18n": "4.0.0"
@@ -3080,7 +3080,7 @@
         "fs-write-stream-atomic": "1.0.10",
         "iferr": "0.1.5",
         "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
+        "rimraf": "2.6.3",
         "run-queue": "1.0.3"
       }
     },
@@ -3637,7 +3637,7 @@
         "is-path-in-cwd": "1.0.1",
         "p-map": "1.2.0",
         "pify": "3.0.0",
-        "rimraf": "2.6.2"
+        "rimraf": "2.6.3"
       },
       "dependencies": {
         "globby": {
@@ -3930,7 +3930,8 @@
     "email-addresses": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.0.3.tgz",
-      "integrity": "sha512-kUlSC06PVvvjlMRpNIl3kR1NRXLEe86VQ7N0bQeaCZb2g+InShCeHQp/JvyYNTugMnRN2NvJhHlc3q12MWbbpg=="
+      "integrity": "sha512-kUlSC06PVvvjlMRpNIl3kR1NRXLEe86VQ7N0bQeaCZb2g+InShCeHQp/JvyYNTugMnRN2NvJhHlc3q12MWbbpg==",
+      "dev": true
     },
     "emoji-regex": {
       "version": "6.5.1",
@@ -4161,7 +4162,7 @@
         "loader-utils": "1.1.0",
         "object-assign": "4.1.1",
         "object-hash": "1.3.1",
-        "rimraf": "2.6.2"
+        "rimraf": "2.6.3"
       }
     },
     "eslint-module-utils": {
@@ -5019,12 +5020,14 @@
     "filename-reserved-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
-      "integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q="
+      "integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=",
+      "dev": true
     },
     "filenamify": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
       "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
+      "dev": true,
       "requires": {
         "filename-reserved-regex": "1.0.0",
         "strip-outer": "1.0.1",
@@ -5035,6 +5038,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/filenamify-url/-/filenamify-url-1.0.0.tgz",
       "integrity": "sha1-syvYExnvWGO3MHi+1Q9GpPeXX1A=",
+      "dev": true,
       "requires": {
         "filenamify": "1.2.1",
         "humanize-url": "1.0.1"
@@ -5130,7 +5134,7 @@
       "requires": {
         "circular-json": "0.3.3",
         "graceful-fs": "4.1.15",
-        "rimraf": "2.6.2",
+        "rimraf": "2.6.3",
         "write": "0.2.1"
       }
     },
@@ -6029,6 +6033,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-2.0.1.tgz",
       "integrity": "sha512-uFlk3bukljeiWKQ2XvPfjcSi/ou7IfoDf2p+Fj672saLAr8bnOdFVqI/JSgrSgInKpCg5BksxEwGUl++dbg8Dg==",
+      "dev": true,
       "requires": {
         "async": "2.6.1",
         "commander": "2.19.0",
@@ -6037,13 +6042,14 @@
         "fs-extra": "7.0.0",
         "globby": "6.1.0",
         "graceful-fs": "4.1.15",
-        "rimraf": "2.6.2"
+        "rimraf": "2.6.3"
       },
       "dependencies": {
         "globby": {
           "version": "6.1.0",
           "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "dev": true,
           "requires": {
             "array-union": "1.0.2",
             "glob": "7.1.3",
@@ -6876,6 +6882,7 @@
       "version": "1.0.1",
       "resolved": "http://registry.npmjs.org/humanize-url/-/humanize-url-1.0.1.tgz",
       "integrity": "sha1-9KuZ4NKIF0yk4eUEB8VfuuRk7/8=",
+      "dev": true,
       "requires": {
         "normalize-url": "1.9.1",
         "strip-url-auth": "1.0.1"
@@ -6885,6 +6892,7 @@
           "version": "1.9.1",
           "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
           "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+          "dev": true,
           "requires": {
             "object-assign": "4.1.1",
             "prepend-http": "1.0.4",
@@ -7269,7 +7277,8 @@
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -7474,7 +7483,7 @@
         "debug": "3.2.6",
         "istanbul-lib-coverage": "1.2.1",
         "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
+        "rimraf": "2.6.3",
         "source-map": "0.5.7"
       }
     },
@@ -7535,7 +7544,7 @@
             "node-notifier": "5.3.0",
             "prompts": "0.1.14",
             "realpath-native": "1.0.2",
-            "rimraf": "2.6.2",
+            "rimraf": "2.6.3",
             "slash": "1.0.0",
             "string-length": "2.0.0",
             "strip-ansi": "4.0.0",
@@ -8689,7 +8698,7 @@
         "copy-concurrently": "1.0.5",
         "fs-write-stream-atomic": "1.0.10",
         "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
+        "rimraf": "2.6.3",
         "run-queue": "1.0.3"
       }
     },
@@ -11092,7 +11101,8 @@
     "prepend-http": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true
     },
     "preserve": {
       "version": "0.2.0",
@@ -11271,6 +11281,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+      "dev": true,
       "requires": {
         "object-assign": "4.1.1",
         "strict-uri-encode": "1.1.0"
@@ -12280,9 +12291,9 @@
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
         "glob": "7.1.3"
       }
@@ -13112,6 +13123,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "dev": true,
       "requires": {
         "is-plain-obj": "1.1.0"
       }
@@ -13350,7 +13362,8 @@
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true
     },
     "string-length": {
       "version": "2.0.0",
@@ -13457,6 +13470,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
       "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "dev": true,
       "requires": {
         "escape-string-regexp": "1.0.5"
       }
@@ -13464,7 +13478,8 @@
     "strip-url-auth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-url-auth/-/strip-url-auth-1.0.1.tgz",
-      "integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164="
+      "integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=",
+      "dev": true
     },
     "style-loader": {
       "version": "0.23.0",
@@ -13855,6 +13870,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+      "dev": true,
       "requires": {
         "escape-string-regexp": "1.0.5"
       }
@@ -13969,7 +13985,7 @@
             "mkdirp": "0.5.1",
             "move-concurrently": "1.0.1",
             "promise-inflight": "1.0.1",
-            "rimraf": "2.6.2",
+            "rimraf": "2.6.3",
             "ssri": "5.3.0",
             "unique-filename": "1.1.1",
             "y18n": "4.0.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "homepage": "https://appnroll.github.io/kudosapp-frontend/",
   "dependencies": {
-    "gh-pages": "^2.0.1",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
     "react-router-dom": "^4.3.1",
@@ -16,8 +15,10 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "predeploy": "npm run build",
-    "deploy": "gh-pages -d build"
+    "deploy:clean": "rimraf build",
+    "deploy:build": "npm run build",
+    "deploy:ship": "gh-pages -d build",
+    "deploy": "npm run deploy:clean && npm run deploy:build && npm run deploy:ship"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -27,5 +28,9 @@
     "not dead",
     "not ie <= 11",
     "not op_mini all"
-  ]
+  ],
+  "devDependencies": {
+    "rimraf": "^2.6.3",
+    "gh-pages": "^2.0.1"
+  }
 }


### PR DESCRIPTION
* moved gh-pages to devDependencies
* added rimraf to be able to dispose dist/build directories cross-platform
* adjusted commands to perform 1. cleaning > 2. building > 3. deploying

It proved, that there were just some leftovers from local builds on the GH Pages; this PR ensures that we will push only production stuff to GH Pages.

cc @Tuhaj 