### PR TITLE
chore: make the spinner and loadMode button share same DOM container to keep them visually in place

### DIFF
--- a/src/components/ListOfCards.js
+++ b/src/components/ListOfCards.js
@@ -54,7 +54,6 @@ const Controls = styled.nav`
   margin: 2rem 0;
   display: flex;
   justify-content: center;
-  min-height: ;
 `
 
 export default ListOfCards

--- a/src/components/ListOfCards.js
+++ b/src/components/ListOfCards.js
@@ -1,8 +1,7 @@
-import React, { Component, createRef } from 'react';
+import React, { Component, createRef } from 'react'
 import styled from 'styled-components'
-import KudoCard from "./KudoCard";
+import KudoCard from "./KudoCard"
 import KudosRequest from './KudosRequest'
-import NetworkSpinner from './NetworkSpinner'
 import LoadMoreButton from './LoadMoreButton'
 
 class ListOfCards extends Component {
@@ -30,7 +29,6 @@ class ListOfCards extends Component {
                                 }
                             </KudosList>
                             <Controls>
-                                <NetworkSpinner/>
                                 {
                                     hasNext &&
                                     <LoadMoreButton onClick={this.request.current.next}>Load more</LoadMoreButton>
@@ -43,7 +41,7 @@ class ListOfCards extends Component {
                     )
                 }}
             </KudosRequest>
-        );
+        )
     }
 }
 
@@ -56,6 +54,7 @@ const Controls = styled.nav`
   margin: 2rem 0;
   display: flex;
   justify-content: center;
+  min-height: ;
 `
 
 export default ListOfCards

--- a/src/components/LoadMoreButton.js
+++ b/src/components/LoadMoreButton.js
@@ -1,7 +1,8 @@
-import React from 'react';
+import React from 'react'
 import styled from 'styled-components'
 import withNetworking from './withNetworking'
 import Colors from '../constants/Colors'
+import NetworkSpinner from './NetworkSpinner'
 
 const LoadButton = styled.button`
   border: 1px solid ${Colors.Banana}; 
@@ -11,8 +12,16 @@ const LoadButton = styled.button`
   padding: 1rem 3rem;
 `
 
-function LoadMoreButton({networking, onClick, children}) {
-    return networking.fetching ? null : <LoadButton onClick={onClick}>{children}</LoadButton>
-}
+const Container = styled.div`
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+`
+
+const LoadMoreButton = ({networking, onClick, children}) => (
+    <Container>
+        {networking.fetching ? <NetworkSpinner/> : <LoadButton onClick={onClick}>{children}</LoadButton>}
+    </Container>
+)
 
 export default withNetworking(LoadMoreButton)

--- a/src/components/NetworkSpinner.js
+++ b/src/components/NetworkSpinner.js
@@ -3,7 +3,7 @@ import Spinner from './Spinner'
 import withNetworking from './withNetworking'
 
 function NetworkSpinner({networking}) {
-    return true ? <Spinner/> : null
+    return networking.fetching ? <Spinner/> : null
 }
 
 export default withNetworking(NetworkSpinner)

--- a/src/components/NetworkSpinner.js
+++ b/src/components/NetworkSpinner.js
@@ -3,7 +3,7 @@ import Spinner from './Spinner'
 import withNetworking from './withNetworking'
 
 function NetworkSpinner({networking}) {
-    return networking.fetching ? <Spinner/> : null
+    return true ? <Spinner/> : null
 }
 
 export default withNetworking(NetworkSpinner)


### PR DESCRIPTION
fixes https://github.com/Appnroll/kudosapp-frontend/issues/46