### PR TITLE
chore: force instruction text to be left-aligned

### DIFF
--- a/src/components/Instructions.js
+++ b/src/components/Instructions.js
@@ -64,6 +64,7 @@ const Number = styled.div`
 `
 const Description = styled.div`
    font-size: 16px;
+   text-align: left;
 `
 const Code = styled.span`
    color: ${Colors.GlacierBlue}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/3466388/52569514-a4758e00-2e11-11e9-9d66-4312778d3d62.png)

After:
![image](https://user-images.githubusercontent.com/3466388/52569496-9b84bc80-2e11-11e9-8225-e9282dd1b090.png)
