### PR TITLE
chore: allow to specify dev/prod API url

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+export REACT_APP_API_URL=https://kudosapp-production.herokuapp.com/

--- a/.env.staging
+++ b/.env.staging
@@ -1,0 +1,1 @@
+export REACT_APP_API_URL=https://kudosapp-staging.herokuapp.com/

--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
     "styled-components": "^4.1.2"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "source .env.staging && react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "deploy:clean": "rimraf build",
-    "deploy:build": "npm run build",
+    "deploy:build": "source .env && npm run build",
     "deploy:ship": "gh-pages -d build",
     "deploy": "npm run deploy:clean && npm run deploy:build && npm run deploy:ship"
   },
@@ -30,7 +30,7 @@
     "not op_mini all"
   ],
   "devDependencies": {
-    "rimraf": "^2.6.3",
-    "gh-pages": "^2.0.1"
+    "gh-pages": "^2.0.1",
+    "rimraf": "^2.6.3"
   }
 }

--- a/src/components/LoginWithSlackButton.js
+++ b/src/components/LoginWithSlackButton.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 
 const scope = 'identity.basic'
 const clientId = '9591341856.520040322359' // TODO: possibly move to ENV
-const redirectUri = encodeURIComponent('https://kudosapp-staging.herokuapp.com/slack/redirect')
+const redirectUri = encodeURIComponent(`${process.env.REACT_APP_API_URL}slack/redirect`)
 const slackUrl = `https://slack.com/oauth/authorize?scope=${scope}&client_id=${clientId}&redirect_uri=${redirectUri}`
 
 class LoginWithSlackButton extends Component {

--- a/src/components/Request.js
+++ b/src/components/Request.js
@@ -26,7 +26,7 @@ class RequestMaker extends Component {
     }
 
     static get endpoint() {
-        return 'https://kudosapp-production.herokuapp.com/'
+        return process.env.REACT_APP_API_URL
     }
 
     state = {


### PR DESCRIPTION
`.env`, unlikely as on backend, can be committed to repo - it will not contain any secure information anyway. 